### PR TITLE
Prioritize explicit namespace on element declaration above namespace on element type when generating XML

### DIFF
--- a/lib/happymapper/supported_types.rb
+++ b/lib/happymapper/supported_types.rb
@@ -109,12 +109,12 @@ module HappyMapper
       Time.parse(value.to_s) rescue Time.at(value.to_i)
     end
 
-    register_type Date do |value|
-      Date.parse(value.to_s)
-    end
-
     register_type DateTime do |value|
       DateTime.parse(value.to_s)
+    end
+
+    register_type Date do |value|
+      Date.parse(value.to_s)
     end
 
     register_type Boolean do |value|


### PR DESCRIPTION
When an element declaration specifies a specific namespace, like in
````
class CoffeeMachine
  element 'beverage', Beverage, namespace: 'beverages'
end
````
then that namespace should be used instead of the namespace declared by the
element type itself, which could e.g. be
````
class Beverage
  namespace 'coffee'
  attribute 'name', String
end
````

It used to be the case that a nested 'beverage' element would use the 'coffee'
namespaces. With this patch it uses the 'beverages' namespace.

This is necessary to produce the correct XML for cases where e.g. one XSD
specifies a type and another XSD uses that type, which is common in various
standard XSD's, as in the example below.

There is one 'victim': attribute namespacing. To namespace an attribute, you
now always explicitly need to specify the namespace. As attribute namespacing
is a rarely used feature of XML, I think that is a sacrifice we should be willing
to make.

Example
-------
We are dealing with a Subscribe element from the ws-base-notification XSD,
which has a ConsumerReference element which is of type EndpointReferenceType from
the ws-addressing XSD. The classes reflecting the XSD's look like:
````
class WsBaseNotification::Subscribe
  register_namespace 'add', 'http://www.w3.org/2005/08/addressing'
  register_namespace 'b', 'http://docs.oasis-open.org/wsn/b-2'

  namespace 'b'
  has_one :ConsumerReference, WsAddressing::EndpointReferenceType, namespace: 'b'
  ...
end

class WsAddressing::EndPointReferenceType
  namespace 'add'
  ...
end
````
(note that 'b' and 'add' are the preferred prefixes for
 'http://docs.oasis-open.org/wsn/b-2' and 'http://www.w3.org/2005/08/addressing')

The XML that used to be produced would be
````
<b:Subscribe ...>
  <add:ConsumerReference> ...
````
Now it is:
````
<b:Subscribe ...>
  <b:ConsumerReference> ...
````