### PR TITLE
restore after_parse callback support

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -185,6 +185,22 @@ module HappyMapper
     end
 
     #
+    # The list of registered after_parse callbacks.
+    #
+    def after_parse_callbacks
+      @after_parse_callbacks ||= []
+    end
+
+    #
+    # Register a new after_parse callback, given as a block.
+    #
+    # @yield [object] Yields the newly-parsed object to the block after parsing.
+    #     Sub-objects will be already populated.
+    def after_parse(&block)
+      after_parse_callbacks.push(block)
+    end
+
+    #
     # Specify a namespace if a node and all its children are all namespaced
     # elements. This is simpler than passing the :namespace option to each
     # defined element.
@@ -431,6 +447,10 @@ module HappyMapper
             n = n.children if n.respond_to?(:children)
             obj.xml_content = n.to_xml
           end
+
+          # Call any registered after_parse callbacks for the object's class
+
+          obj.class.after_parse_callbacks.each { |callback| callback.call(obj) }
 
           # collect the object that we have created
 

--- a/spec/happymapper_parse_spec.rb
+++ b/spec/happymapper_parse_spec.rb
@@ -82,6 +82,32 @@ describe HappyMapper do
       end
     end
 
+    context "after_parse callbacks" do
+      module AfterParseSpec
+        class Address
+          include HappyMapper
+          element :street, String
+        end
+      end
+
+      after do
+        AfterParseSpec::Address.after_parse_callbacks.clear
+      end
+
+      it "should callback with the newly created object" do
+        from_cb = nil
+        called = false
+        cb1 = proc { |object| from_cb = object }
+        cb2 = proc { called = true }
+        AfterParseSpec::Address.after_parse(&cb1)
+        AfterParseSpec::Address.after_parse(&cb2)
+
+        object = AfterParseSpec::Address.parse fixture_file('address.xml')
+        from_cb.should == object
+        called.should == true
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
I pulled this in unchanged from the original happymapper gem, because our goal is to port our gem https://github.com/instructure/moodle2cc over to nokogiri-happymapper. I'm up for any changes you'd like to see, though.