### PR TITLE
preserve xml value

### DIFF
--- a/lib/happymapper.rb
+++ b/lib/happymapper.rb
@@ -436,7 +436,7 @@ module HappyMapper
 
           if obj.respond_to?('xml_value=')
             n.namespaces.each {|name,path| n[name] = path }
-            obj.xml_value = n.to_xml
+            obj.xml_value = n.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
           end
 
           # If the HappyMapper class has the method #xml_content=,
@@ -445,7 +445,7 @@ module HappyMapper
 
           if obj.respond_to?('xml_content=')
             n = n.children if n.respond_to?(:children)
-            obj.xml_content = n.to_xml
+            obj.xml_content = n.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
           end
 
           # Call any registered after_parse callbacks for the object's class

--- a/spec/fixtures/unformatted_address.xml
+++ b/spec/fixtures/unformatted_address.xml
@@ -1,0 +1,1 @@
+<address><street>Milchstrasse</street><housenumber>23</housenumber></address>

--- a/spec/happymapper_spec.rb
+++ b/spec/happymapper_spec.rb
@@ -89,6 +89,9 @@ end
 class Address
   include HappyMapper
 
+  attr_accessor :xml_value
+  attr_accessor :xml_content
+
   tag 'address'
   element :street, String
   element :postcode, String
@@ -1110,6 +1113,24 @@ describe HappyMapper do
     it 'can clear @nokogiri_config_callback' do
       custom.with_nokogiri_config {}
       expect { custom.parse(fixture_file('set_config_options.xml')) }.to raise_error(Nokogiri::XML::SyntaxError)
+    end
+  end
+
+  context 'xml_value' do
+    it 'does not reformat the xml' do
+      xml = fixture_file('unformatted_address.xml')
+      address = Address.parse(xml, single: true)
+
+      expect(address.xml_value).to eq %{<address><street>Milchstrasse</street><housenumber>23</housenumber></address>}
+    end
+  end
+
+  context 'xml_content' do
+    it 'does not reformat the xml' do
+      xml = fixture_file('unformatted_address.xml')
+      address = Address.parse(xml)
+
+      expect(address.xml_content).to eq %{<street>Milchstrasse</street><housenumber>23</housenumber>}
     end
   end
 


### PR DESCRIPTION
to_xml has a default of reformatting the XML if its one line. I expected xml_value to return the original unformatted xml.