### PR TITLE
Add rescue for when value is nil

### DIFF
--- a/lib/happymapper/supported_types.rb
+++ b/lib/happymapper/supported_types.rb
@@ -110,11 +110,11 @@ module HappyMapper
     end
 
     register_type DateTime do |value|
-      DateTime.parse(value.to_s) rescue value
+      DateTime.parse(value.to_s) if value
     end
 
     register_type Date do |value|
-      Date.parse(value.to_s) rescue value
+      Date.parse(value.to_s) if value
     end
 
     register_type Boolean do |value|

--- a/lib/happymapper/supported_types.rb
+++ b/lib/happymapper/supported_types.rb
@@ -110,11 +110,11 @@ module HappyMapper
     end
 
     register_type DateTime do |value|
-      DateTime.parse(value.to_s)
+      DateTime.parse(value.to_s) rescue value
     end
 
     register_type Date do |value|
-      Date.parse(value.to_s)
+      Date.parse(value.to_s) rescue value
     end
 
     register_type Boolean do |value|

--- a/spec/happymapper/item_spec.rb
+++ b/spec/happymapper/item_spec.rb
@@ -102,9 +102,19 @@ describe HappyMapper::Item do
       item.typecast('2000-01-01').should == Date.new(2000, 1, 1)
     end
 
+    it "should handle nil Dates" do
+      item = HappyMapper::Item.new(:foo, Date)
+      item.typecast(nil).should == nil
+    end
+
     it "should work with DateTimes" do
       item = HappyMapper::Item.new(:foo, DateTime)
       item.typecast('2000-01-01 00:00:00').should == DateTime.new(2000, 1, 1, 0, 0, 0)
+    end
+
+    it "should handle nil DateTimes" do
+      item = HappyMapper::Item.new(:foo, DateTime)
+      item.typecast(nil).should == nil
     end
 
     it "should work with Boolean" do


### PR DESCRIPTION
When date times and dates are null from a XML source.  The parser fails because it cant parse a `nil` object. This will handle that and just rescue/return the `nil` value